### PR TITLE
Fix body without fr in subject page organization

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -242,7 +242,9 @@ export const SPARQL_CONSTRUCTS = [
                       skos:prefLabel ?nameWithLang ;
                       org:classification ?organizationType .
 
-                ?body org:hasSubOrganization ?org .
+                ?body a org:Organization ;
+                      org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> ;
+                      org:hasSubOrganization ?org .
 
                 ?organizationType a euvoc:CorporateBodyClassification, skos:Concept ;
                                   skos:prefLabel ?organizationTypeNameWithLang .
@@ -255,7 +257,8 @@ export const SPARQL_CONSTRUCTS = [
                         oparl:organizationType ?organizationTypeName ;
                         oparl:membership ?membership .
 
-                BIND(URI(?bodyStr) as ?body)
+                # Freiburg OParl API has a bug that /body is used instead of /body/FR in the subject page of an organization
+                BIND(IF(?bodyStr = "https://ris.freiburg.de/oparl/body", URI("https://ris.freiburg.de/oparl/body/FR"), URI(?bodyStr)) as ?body)
                 BIND(URI(CONCAT(STR('http://data.lblod.info/id/concepts/corporateBodyClassification/'), MD5(?organizationTypeName))) as ?organizationType)
                 BIND(strlang(?name, 'de') as ?nameWithLang)
                 BIND(strlang(?organizationTypeName, 'de') as ?organizationTypeNameWithLang)


### PR DESCRIPTION
Fixes issue with OParl API from Freiburg.
What is expected, when retrieving:
`https://ris.freiburg.de/oparl/body/FR/organization` 
```
"id": "https://ris.freiburg.de/oparl/organization/Mib",
"type": "https://schema.oparl.org/1.0/Organization",
"body": "https://ris.freiburg.de/oparl/body/FR"
```
https://ris.freiburg.de/oparl/organization/Mib has body https://ris.freiburg.de/oparl/body/FR.
But when retrieving the subject page `https://ris.freiburg.de/oparl/organization/Mib`:
```
"id": "https://ris.freiburg.de/oparl/organization/Mib",
"type": "https://schema.oparl.org/1.0/Organization",
"body": "https://ris.freiburg.de/oparl/body"
```

The body does not contain /FR .