### PR TITLE
Make expression text optional

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -340,9 +340,12 @@ export const SPARQL_CONSTRUCTS = [
                     oparl:name ?name ;
                     oparl:mimeType ?mimeType ;
                     oparl:size ?size ;
-                    oparl:text ?text ;
                     oparl:accessUrl ?accessUrl .
 
+                OPTIONAL {
+                  ?manifestation oparl:text ?text .
+                }
+                  
                 # Create derived IRIs and typed/language-tagged literals
                 BIND(IRI(CONCAT(STR(?manifestation), "/expression/de")) AS ?expression)
                 BIND(STRLANG(?name, "de") AS ?titleLang)


### PR DESCRIPTION
In the conversion of Oparl to ELI, we use the main file of a paper as eli:Expression.
The content is fetched from the "text" property. For example: https://ris.freiburg.de/oparl/paper/960407100030

However, some files don't have a "text" property. For example, https://ris.freiburg.de/oparl/paper/5941911100009
This resulted that the expression is published.

This PR makes "text" optional, resulting in an expression without content.