### PR TITLE
Update check is Subject page

### DIFF
--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -84,10 +84,13 @@ export async function process(task, url, taskSpecificQueue: PQueue) {
     );
   }
 
-  // Only write ELI data if no linkToPublications were found
-  // No linkToPublications means the response is a subject page (leaf node) with ELI data and we can diff on in a next task
-  // If the page has linkToPublications, then this is a paginated page and we expect this to not be idempotent
-  if (linkToPublications.length === 0) {
+  // Only write ELI data if no linkToPublications were found that contain 'page' in the URL
+  // No linkToPublications with 'page' means the response is a subject page with ELI data and we can diff on in a next task
+  // If the page has linkToPublications with 'page', then this is a paginated collection of entities and we expect this to not be idempotent
+  const isSubjectPage =
+    linkToPublications.length === 0 ||
+    linkToPublications.filter((l) => l.includes('page')).length === 0;
+  if (isSubjectPage) {
     const fileResult = await writeFileToTriplestore(
       task.graph,
       convertedOparlData,


### PR DESCRIPTION
This PR changes the logic of checking whether an URL is a subject page.
This allows https://ris.freiburg.de/oparl/Body/FR to be a subject page, although it contains linkToPublications.

The result is visible in the frontend dashboard:
<img width="767" height="585" alt="image" src="https://github.com/user-attachments/assets/e0a6c5fb-2d0a-4228-b31a-2c9eafbe1a1f" />
