### PR TITLE
chore(doc): minor updates in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Add the following snippet in your docker-compose.yml:
 oparl-to-eli:
     image: lblod/oparl-to-eli-service:0.0.6
     volumes:
-      - ../config/oparl-to-eli/:/config/
       - ../data/files:/share
     environment:
       OPARL_ENDPOINT: 'https://ris.freiburg.de/oparl'

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ oparl-to-eli:
 
 ## Environment variables
 
-* `OPARL_ENDPOINT`: (string) (OPTIONAL) OParl endpoint to expose with proxy API, for example: 'https://ris.freiburg.de/oparl'
+* `OPARL_ENDPOINT`: (string) OParl endpoint to expose with proxy API, for example: 'https://ris.freiburg.de/oparl'
 * `EMBED_JSONLD_CONTEXT`: (boolean) whether the JSON-LD context should be provided inside the response or just linked. Default 'true'
 * `WRITE_TO_GRAPH`: (string) write all triples retrieved from OParl to this graph, e.g. 'http://mu.semte.ch/graphs/landing/oparl'. Default '', because all data is written to files for the add-uuid and diff service
 


### PR DESCRIPTION
This corrects two issues in the README.
1. The `OPARL_ENDPOINT` environment variable was marked as optional but this is actually a required environment variable, see `requiredEnv` in `app.ts`.
2. The docker compose example mounts a `config/oparl-to-eli` volume, but this service thus not have or uses a `config` folder.